### PR TITLE
Fix Time.get_ticks_msec references

### DIFF
--- a/scripts/Zone.gd
+++ b/scripts/Zone.gd
@@ -6,7 +6,7 @@ var idle_timeout := 2.0
 func spawn_entity(id: int):
     var npc := CharacterBody3D.new()
     add_child(npc)
-    entities[id] = {"node": npc, "last_move": OS.get_ticks_msec()/1000.0}
+    entities[id] = {"node": npc, "last_move": Time.get_ticks_msec()/1000.0}
 
 func remove_entity(id:int):
     if entities.has(id):
@@ -17,10 +17,10 @@ func move_entity(id:int, pos:Vector3):
     if entities.has(id):
         var info = entities[id]
         info["node"].global_transform.origin = info["node"].global_transform.origin.lerp(pos, 0.25)
-        info["last_move"] = OS.get_ticks_msec()/1000.0
+        info["last_move"] = Time.get_ticks_msec()/1000.0
 
 func _process(delta):
-    var t = OS.get_ticks_msec()/1000.0
+    var t = Time.get_ticks_msec()/1000.0
     for id in entities.keys():
         var info = entities[id]
         if t - info["last_move"] > idle_timeout:


### PR DESCRIPTION
## Summary
- fix references to `OS.get_ticks_msec` which is invalid in Godot 4

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b01ca4188331806b192a032692ad