### PR TITLE
Add dungeon_new scene for playable dungeon

### DIFF
--- a/scenes/dungeon_new.tscn
+++ b/scenes/dungeon_new.tscn
@@ -1,0 +1,89 @@
+[gd_scene format=3]
+
+[ext_resource path="res://scripts/Player.gd" type="Script" id="1"]
+[ext_resource path="res://assets/environments/mini_dungeon/GLB format/floor.glb" type="PackedScene" id="2"]
+[ext_resource path="res://assets/environments/mini_dungeon/GLB format/floor-detail.glb" type="PackedScene" id="3"]
+[ext_resource path="res://assets/environments/mini_dungeon/GLB format/wall.glb" type="PackedScene" id="4"]
+[ext_resource path="res://assets/characters/test_char/Skeleton_Warrior.glb" type="PackedScene" id="5"]
+
+[sub_resource type="BoxShape3D" id="1"]
+size = Vector3(12, 1, 12)
+
+[sub_resource type="BoxShape3D" id="2"]
+size = Vector3(12, 4, 0.5)
+
+[node name="dungeon_new" type="Node3D"]
+
+[node name="Floor1" parent="." instance=ExtResource("2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, -4)
+
+[node name="Floor2" parent="." instance=ExtResource("2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, -4)
+
+[node name="Floor3" parent="." instance=ExtResource("2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, 4)
+
+[node name="Floor4" parent="." instance=ExtResource("2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 4)
+
+[node name="Hallway1" parent="." instance=ExtResource("2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12, 0, 0)
+
+[node name="Hallway2" parent="." instance=ExtResource("2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 12)
+
+[node name="FloorDetail1" parent="." instance=ExtResource("3")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
+
+[node name="FloorDetail2" parent="." instance=ExtResource("3")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 0)
+
+[node name="Walls" type="Node3D" parent="."]
+
+[node name="NorthWall" type="Node3D" parent="Walls" instance=ExtResource("4")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -6)
+
+[node name="SouthWall" type="Node3D" parent="Walls" instance=ExtResource("4")]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 6)
+
+[node name="EastWall" type="Node3D" parent="Walls" instance=ExtResource("4")]
+transform = Transform3D(0, 0, 1, 0, 1, 0, -1, 0, 0, 6, 0, 0)
+
+[node name="WestWall" type="Node3D" parent="Walls" instance=ExtResource("4")]
+transform = Transform3D(0, 0, -1, 0, 1, 0, 1, 0, 0, -6, 0, 0)
+
+[node name="FloorCollision" type="StaticBody3D" parent="."]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="FloorCollision"]
+shape = SubResource("1")
+
+[node name="WallCollisionNorth" type="StaticBody3D" parent="Walls"]
+[node name="CollisionShapeNorth" type="CollisionShape3D" parent="WallCollisionNorth"]
+shape = SubResource("2")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, -6)
+
+[node name="WallCollisionSouth" type="StaticBody3D" parent="Walls"]
+[node name="CollisionShapeSouth" type="CollisionShape3D" parent="WallCollisionSouth"]
+shape = SubResource("2")
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 2, 6)
+
+[node name="WallCollisionEast" type="StaticBody3D" parent="Walls"]
+[node name="CollisionShapeEast" type="CollisionShape3D" parent="WallCollisionEast"]
+shape = SubResource("2")
+transform = Transform3D(0, 0, 1, 0, 1, 0, -1, 0, 0, 6, 2, 0)
+
+[node name="WallCollisionWest" type="StaticBody3D" parent="Walls"]
+[node name="CollisionShapeWest" type="CollisionShape3D" parent="WallCollisionWest"]
+shape = SubResource("2")
+transform = Transform3D(0, 0, -1, 0, 1, 0, 1, 0, 0, -6, 2, 0)
+
+[node name="Player" parent="." instance=ExtResource("5")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
+script = ExtResource("1")
+
+[node name="Camera3D" type="Camera3D" parent="Player"]
+transform = Transform3D(1, 0, 0, 0, 0.707106, -0.707106, 0, 0.707106, 0.707106, 0, 10, 10)
+current = true
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(0.707106, 0, 0.707106, -0.5, 0.866025, -0.5, -0.5, 0.5, 0.707106, 0, 5, 0)
+light_energy = 2.0


### PR DESCRIPTION
## Summary
- create a new dungeon scene with floors, walls, hallways, player and camera
- re-use existing `Player.gd` script for basic movement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876be940a4c8331aa2b75a12af2686a