### PR TITLE
Fix Player node type in dungeon scene

### DIFF
--- a/scenes/dungeon_new.tscn
+++ b/scenes/dungeon_new.tscn
@@ -80,8 +80,10 @@ shape = SubResource("2")
 transform = Transform3D(0, 0, -1, 0, 1, 0, 1, 0, 0, -6, 2, 0)
 shape = SubResource("2")
 
-[node name="Player" parent="." instance=ExtResource("5")]
+[node name="Player" type="CharacterBody3D" parent="."]
 script = ExtResource("1")
+
+[node name="Skeleton_Warrior" parent="Player" instance=ExtResource("5")]
 
 [node name="Camera3D" type="Camera3D" parent="Player"]
 transform = Transform3D(1, 0, 0, 0, 0.707106, -0.707106, 0, 0.707106, 0.707106, 0, 10, 10)


### PR DESCRIPTION
## Summary
- make `Player` a `CharacterBody3D` in `dungeon_new.tscn`
- instance the Skeleton_Warrior model as a child so the Player script matches the node type

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6876c169642c8331b9a4f4f5641b4df7