### PR TITLE
Add top‑down camera

### DIFF
--- a/scenes/dungeon_new.tscn
+++ b/scenes/dungeon_new.tscn
@@ -86,7 +86,7 @@ script = ExtResource("1")
 [node name="Skeleton_Warrior" parent="Player" instance=ExtResource("5")]
 
 [node name="Camera3D" type="Camera3D" parent="Player"]
-transform = Transform3D(1, 0, 0, 0, 0.707106, -0.707106, 0, 0.707106, 0.707106, 0, 10, 10)
+transform = Transform3D(1, 0, 0, 0, 0.5, -0.866025, 0, 0.866025, 0.5, 0, 10, -6)
 current = true
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]


### PR DESCRIPTION
## Summary
- adjust dungeon camera for a top‑down ARPG view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876c2cddb5c833188755e2b7bd2a524