### PR TITLE
Fix visibility for dungeon scene

### DIFF
--- a/scenes/dungeon_new.tscn
+++ b/scenes/dungeon_new.tscn
@@ -15,7 +15,7 @@ size = Vector3(12, 4, 0.5)
 [node name="dungeon_new" type="Node3D"]
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
-transform = Transform3D(0.707106, 0.661225, 0.250563, -0.5, 0.718119, -0.48405, -0.5, 0.216994, 0.838399, 0, 5, 0)
+transform = Transform3D(0.866025, 0.383022, 0.321394, 0, 0.642788, -0.766044, -0.5, 0.663414, 0.55667, 0, 10, 0)
 light_energy = 2.0
 
 [node name="Floor1" parent="." instance=ExtResource("2")]
@@ -86,9 +86,10 @@ shape = SubResource("2")
 
 [node name="Player" type="CharacterBody3D" parent="."]
 script = ExtResource("1")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
 
 [node name="Skeleton_Warrior" parent="Player" instance=ExtResource("5")]
 
 [node name="Camera3D" type="Camera3D" parent="Player"]
-transform = Transform3D(1, 0, 0, 0, 0.5, -0.866025, 0, 0.866025, 0.5, 0, 10, -6)
+transform = Transform3D(-1, 0, 0, 0, 0.422618, -0.906308, 0, -0.906308, -0.422618, 0, 15, 20)
 current = true

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -19,14 +19,20 @@ func get_movement_input() -> Vector3:
 	return dir.normalized()
 
 func _physics_process(_delta):
-	var dir = get_movement_input()
-	var target_velocity = dir * SPEED
-	velocity.x = lerp(velocity.x, target_velocity.x, 0.2)
-	velocity.z = lerp(velocity.z, target_velocity.z, 0.2)
-	move_and_slide()
+        var dir = get_movement_input()
+        var target_velocity = dir * SPEED
+        velocity.x = lerp(velocity.x, target_velocity.x, 0.2)
+        velocity.z = lerp(velocity.z, target_velocity.z, 0.2)
+        move_and_slide()
 
 	var delta_pos = global_transform.origin - last_position
 	if delta_pos.length() > 0:
-		if get_node_or_null("../NetworkManager"):
-			get_node("../NetworkManager").send_movement(delta_pos)
-		last_position = global_transform.origin
+                if get_node_or_null("../NetworkManager"):
+                        get_node("../NetworkManager").send_movement(delta_pos)
+                last_position = global_transform.origin
+
+func _input(event):
+        if event is InputEventKey and event.pressed and event.keycode == KEY_C:
+                if has_node("Camera3D"):
+                        var cam = get_node("Camera3D")
+                        print("Camera position:", cam.global_transform.origin)


### PR DESCRIPTION
## Summary
- ensure the player is placed above the floor
- reposition the dungeon directional light
- adjust the camera transform for a top-down view
- add a debug input in `Player.gd` to log camera position

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c91aec34833186d695871fed0402